### PR TITLE
Update fourch.py

### DIFF
--- a/fourch/fourch.py
+++ b/fourch/fourch.py
@@ -2,10 +2,10 @@
 from ._version import __version__
 
 urls = {
-    "api": "api.4chan.org",
+    "api": "a.4cdn.org",
     "boards": "boards.4chan.org",
-    "images": "images.4chan.org",
-    "thumbs": "0.thumbs.4chan.org",
+    "images": "i.4cdn.org",
+    "thumbs": "t.4cdn.org",
 
     # These are tacked to the end of the api url after formatting.
     "api_board": "/{board}/{page}.json",


### PR DESCRIPTION
Updates the urls to the new cookie-less domain as requested on the 4chan API documentation.
https://github.com/4chan/4chan-API

api.4chan.org --> a.4cdn.org
images.4chan.org --> i.4cdn.org
0.thumbs.4chan.org --> t.4cdn.org
